### PR TITLE
feat:WGPU support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -12,6 +12,9 @@ pub fn build(b: *std.Build) void {
         .renderer = config.renderer,
     });
     const cimgui_mod = cimgui_dep.module("cimgui");
+    const wgpu_native_dep = b.dependency("wgpu_native_zig", .{
+        .target = config.target,
+    });
 
     const exe_mod = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
@@ -32,6 +35,7 @@ pub fn build(b: *std.Build) void {
             .flags = &.{},
         });
     }
+    exe_mod.addImport("wgpu", wgpu_native_dep.module("wgpu"));
     exe_mod.addOptions("build_options", options);
     exe_mod.linkLibrary(cimgui_dep.artifact("cimgui_impl"));
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,6 +7,10 @@
         .cimgui = .{ .path = "vendor/cimgui" },
         .opengl = .{ .path = "vendor/opengl", .lazy = true },
         .sdl_image = .{ .path = "vendor/sdl_image" },
+        .wgpu_native_zig = .{
+            .url = "git+https://github.com/bronter/wgpu_native_zig?ref=main#e08f24e6f09b011f973860ce4f13e6e07fb3d165",
+            .hash = "wgpu_native_zig-5.1.0-B9jeDJIvAwANqJx4wKH-oAxpiD9HFHYzLOFaxHsV9piX",
+        },
     },
     .paths = .{
         "build.zig",

--- a/imgui.ini
+++ b/imgui.ini
@@ -14,8 +14,8 @@ Size=402,391
 Collapsed=0
 
 [Window][Ember Debug Console]
-Pos=5,11
-Size=339,65
+Pos=29,222
+Size=554,250
 Collapsed=0
 
 [Docking][Data]

--- a/perf.csv
+++ b/perf.csv
@@ -1,0 +1,1 @@
+sprite_count,fps

--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -8,7 +8,7 @@ optimize: std.builtin.OptimizeMode,
 target: std.Build.ResolvedTarget,
 
 /// Comptime interfaces
-renderer: Renderer.BackendType = .SDL,
+renderer: Renderer.BackendType = .WGPU,
 
 /// This is for the zig build -D options
 pub fn init(b: *std.Build) !Config {

--- a/src/main.zig
+++ b/src/main.zig
@@ -237,7 +237,7 @@ pub fn main() !void {
 
         if (draw_data) |data| { // Check draw_data is not null
             if (data.Valid and data.CmdListsCount > 0) {
-                rendering.renderImGui(renderer_ctx, data);
+                rendering.renderImGui(renderer_ctx, data, clear_color);
             }
         } else {
             std.log.warn("ImGui draw data was null!", .{});

--- a/src/rendering/backend/opengl.zig
+++ b/src/rendering/backend/opengl.zig
@@ -155,7 +155,8 @@ pub fn newImGuiFrame() void {
     ig.ImGui_ImplSDL3_NewFrame();
 }
 
-pub fn renderImGui(_: *Context, draw: *ig.c.ImDrawData) void {
+pub fn renderImGui(_: *Context, draw: *ig.c.ImDrawData, clear_color: ig.c.ImVec4) void {
+    _ = clear_color; // OpenGL backend handles clear color in beginFrame
     ig.ImGui_ImplOpenGL3_RenderDrawData(draw);
 }
 

--- a/src/rendering/backend/wgpu.zig
+++ b/src/rendering/backend/wgpu.zig
@@ -1,0 +1,783 @@
+const std = @import("std");
+const sdl = @import("sdl");
+const ig = @import("cimgui");
+const wgpu = @import("wgpu");
+const RendererInterface = @import("../renderer.zig");
+
+pub const Context = struct {
+    allocator: std.mem.Allocator,
+    window: *sdl.c.SDL_Window,
+    instance: *wgpu.Instance,
+    adapter: ?*wgpu.Adapter,
+    device: ?*wgpu.Device,
+    queue: ?*wgpu.Queue,
+    surface: ?*wgpu.Surface,
+    surface_config: wgpu.SurfaceConfiguration,
+    render_pipeline: ?*wgpu.RenderPipeline,
+    bind_group_layout: ?*wgpu.BindGroupLayout,
+    sampler: ?*wgpu.Sampler,
+    vertex_buffer: ?*wgpu.Buffer,
+    vertices: std.ArrayList(Vertex),
+    width: u32,
+    height: u32,
+    draw_calls: std.ArrayList(DrawCall),
+    vertex_data: std.ArrayList(Vertex),
+};
+
+pub const Texture = struct {
+    texture: *wgpu.Texture,
+    view: *wgpu.TextureView,
+    bind_group: *wgpu.BindGroup,
+    width: u32,
+    height: u32,
+};
+
+const Vertex = struct {
+    position: [2]f32,
+    tex_coords: [2]f32,
+};
+
+const DrawCall = struct {
+    texture_view: *wgpu.TextureView,
+    bind_group: *wgpu.BindGroup,
+    vertex_offset: u32,
+    vertex_count: u32,
+};
+
+pub fn init(allocator: std.mem.Allocator, window: *sdl.c.SDL_Window) RendererInterface.Error!*Context {
+    const ctx = try allocator.create(Context);
+    errdefer allocator.destroy(ctx);
+
+    ctx.allocator = allocator;
+    ctx.window = window;
+    ctx.vertices = std.ArrayList(Vertex).init(allocator);
+    ctx.draw_calls = std.ArrayList(DrawCall).init(allocator);
+    ctx.vertex_data = std.ArrayList(Vertex).init(allocator);
+
+    var w: c_int = 0;
+    var h: c_int = 0;
+    _ = sdl.c.SDL_GetWindowSizeInPixels(window, &w, &h);
+    ctx.width = @intCast(w);
+    ctx.height = @intCast(h);
+
+    var logical_w: c_int = 0;
+    var logical_h: c_int = 0;
+    _ = sdl.c.SDL_GetWindowSize(window, &logical_w, &logical_h);
+
+    std.log.info("WGPU window size - logical: {}x{}, physical: {}x{}", .{ logical_w, logical_h, w, h });
+
+    const instance_desc = wgpu.InstanceDescriptor{
+        .features = wgpu.InstanceCapabilities{
+            .timed_wait_any_enable = 0, // false - disable timed wait features
+            .timed_wait_any_max_count = 0, // not needed since timed wait is disabled
+        },
+    };
+    ctx.instance = wgpu.Instance.create(&instance_desc) orelse {
+        std.log.err("Failed to create WGPU instance", .{});
+        return RendererInterface.Error.InitializationFailed;
+    };
+    errdefer ctx.instance.release();
+
+    ctx.surface = try createSurfaceFromSDLWindow(ctx.instance, window);
+    errdefer if (ctx.surface) |s| s.release();
+
+    const adapter_opts = wgpu.RequestAdapterOptions{
+        .compatible_surface = ctx.surface,
+        .power_preference = .undefined,
+        .force_fallback_adapter = 0,
+    };
+
+    const adapter_response = ctx.instance.requestAdapterSync(&adapter_opts, 200_000_000);
+    ctx.adapter = switch (adapter_response.status) {
+        .success => adapter_response.adapter,
+        else => {
+            std.log.err("Failed to request adapter: {s}", .{adapter_response.message orelse "Unknown error"});
+            return RendererInterface.Error.InitializationFailed;
+        },
+    };
+    errdefer if (ctx.adapter) |a| a.release();
+
+    const device_desc = wgpu.DeviceDescriptor{
+        .label = wgpu.StringView.fromSlice("Device"),
+        .required_feature_count = 0,
+        .required_features = &[_]wgpu.FeatureName{},
+        .required_limits = null,
+        .default_queue = wgpu.QueueDescriptor{
+            .label = wgpu.StringView.fromSlice("Default Queue"),
+        },
+    };
+
+    const device_response = ctx.adapter.?.requestDeviceSync(ctx.instance, &device_desc, 200_000_000);
+    ctx.device = switch (device_response.status) {
+        .success => device_response.device,
+        else => {
+            std.log.err("Failed to request device: {s}", .{device_response.message orelse "Unknown error"});
+            return RendererInterface.Error.InitializationFailed;
+        },
+    };
+    errdefer if (ctx.device) |d| d.release();
+
+    ctx.queue = ctx.device.?.getQueue();
+
+    var surface_caps: wgpu.SurfaceCapabilities = undefined;
+    _ = ctx.surface.?.getCapabilities(ctx.adapter.?, &surface_caps);
+    defer surface_caps.freeMembers();
+
+    const surface_format = if (surface_caps.format_count > 0)
+        surface_caps.formats[0]
+    else
+        .bgra8_unorm;
+
+    ctx.surface_config = wgpu.SurfaceConfiguration{
+        .device = ctx.device.?,
+        .format = surface_format,
+        .usage = wgpu.TextureUsages.render_attachment,
+        .width = ctx.width,
+        .height = ctx.height,
+        .present_mode = .fifo,
+        .alpha_mode = .auto,
+        .view_formats = &[_]wgpu.TextureFormat{},
+        .view_format_count = 0,
+    };
+
+    ctx.surface.?.configure(&ctx.surface_config);
+
+    try createTextureResources(ctx);
+
+    try createRenderPipeline(ctx);
+
+    const vertex_buffer_desc = wgpu.BufferDescriptor{
+        .label = wgpu.StringView.fromSlice("Vertex Buffer"),
+        .usage = wgpu.BufferUsages.vertex | wgpu.BufferUsages.copy_dst,
+        .size = @sizeOf(Vertex) * 6 * 65536,
+        .mapped_at_creation = 0,
+    };
+    ctx.vertex_buffer = ctx.device.?.createBuffer(&vertex_buffer_desc);
+
+    std.log.info("WGPU Renderer initialized successfully", .{});
+    return ctx;
+}
+
+pub fn deinit(allocator: std.mem.Allocator, ctx: *Context) void {
+    std.log.info("Deinitializing WGPU Renderer...", .{});
+
+    if (ctx.vertex_buffer) |vb| vb.release();
+    if (ctx.sampler) |s| s.release();
+    if (ctx.bind_group_layout) |bgl| bgl.release();
+    if (ctx.render_pipeline) |rp| rp.release();
+    if (ctx.surface) |s| s.release();
+    if (ctx.device) |d| d.release();
+    if (ctx.adapter) |a| a.release();
+    ctx.instance.release();
+    ctx.vertices.deinit();
+    ctx.draw_calls.deinit();
+    ctx.vertex_data.deinit();
+
+    allocator.destroy(ctx);
+    std.log.info("Deinitialized WGPU Renderer.", .{});
+}
+
+pub fn beginFrame(ctx: *Context, _: ig.c.ImVec4) RendererInterface.Error!void {
+    ctx.draw_calls.clearRetainingCapacity();
+    ctx.vertex_data.clearRetainingCapacity();
+}
+
+pub fn endFrame(ctx: *Context) RendererInterface.Error!void {
+    _ = ctx;
+}
+
+pub fn initImGuiBackend(ctx: *Context) RendererInterface.Error!void {
+    if (!ig.ImGui_ImplSDL3_InitForOther(ctx.window)) {
+        std.log.err("ImGui_ImplSDL3_InitForOther failed", .{});
+        return RendererInterface.Error.InitializationFailed;
+    }
+
+    var init_info = ig.ImGui_ImplWGPU_InitInfo{
+        .Device = ctx.device,
+        .NumFramesInFlight = 2,
+        .RenderTargetFormat = @as(c_int, @intCast(@intFromEnum(ctx.surface_config.format))),
+        .DepthStencilFormat = @as(c_int, @intCast(@intFromEnum(wgpu.TextureFormat.undefined))),
+        .PipelineMultisampleState = ig.WGPUMultisampleState{
+            .next_in_chain = null,
+            .count = 1,
+            .mask = 0xFFFFFFFF,
+            .alpha_to_coverage_enabled = false,
+        },
+    };
+
+    if (!ig.ImGui_ImplWGPU_Init(&init_info)) {
+        std.log.err("ImGui_ImplWGPU_Init failed", .{});
+        return RendererInterface.Error.InitializationFailed;
+    }
+
+    std.log.info("ImGui WGPU Backend Initialized.", .{});
+}
+
+pub fn deinitImGuiBackend() void {
+    ig.ImGui_ImplWGPU_Shutdown();
+}
+
+pub fn newImGuiFrame() void {
+    ig.ImGui_ImplWGPU_NewFrame();
+}
+
+pub fn renderImGui(ctx: *Context, draw_data: *ig.c.ImDrawData, clear_color: ig.c.ImVec4) void {
+    var surface_texture: wgpu.SurfaceTexture = undefined;
+    ctx.surface.?.getCurrentTexture(&surface_texture);
+    defer if (surface_texture.texture) |texture| texture.release();
+
+    if (surface_texture.status != .success_optimal) {
+        std.log.err("Failed to get current surface texture: status = {}", .{surface_texture.status});
+        return;
+    }
+
+    const view = surface_texture.texture.?.createView(null) orelse {
+        std.log.err("Failed to create texture view", .{});
+        return;
+    };
+    defer view.release();
+
+    const encoder_desc = wgpu.CommandEncoderDescriptor{
+        .label = wgpu.StringView.fromSlice("Command Encoder"),
+    };
+    const encoder = ctx.device.?.createCommandEncoder(&encoder_desc) orelse {
+        std.log.err("Failed to create command encoder", .{});
+        return;
+    };
+    defer encoder.release();
+
+    const render_pass_desc = wgpu.RenderPassDescriptor{
+        .label = wgpu.StringView.fromSlice("Render Pass"),
+        .color_attachment_count = 1,
+        .color_attachments = &[_]wgpu.ColorAttachment{
+            .{
+                .view = view,
+                .resolve_target = null,
+                .load_op = .clear,
+                .store_op = .store,
+                .clear_value = wgpu.Color{
+                    .r = clear_color.x * clear_color.w,
+                    .g = clear_color.y * clear_color.w,
+                    .b = clear_color.z * clear_color.w,
+                    .a = clear_color.w,
+                },
+            },
+        },
+        .depth_stencil_attachment = null,
+        .occlusion_query_set = null,
+        .timestamp_writes = null,
+    };
+
+    const render_pass = encoder.beginRenderPass(&render_pass_desc) orelse {
+        std.log.err("Failed to begin render pass", .{});
+        return;
+    };
+    defer render_pass.release();
+
+    if (ctx.draw_calls.items.len > 0 and ctx.vertex_data.items.len > 0) {
+        const vertex_data_size = ctx.vertex_data.items.len * @sizeOf(Vertex);
+        const max_buffer_size = @sizeOf(Vertex) * 6 * 65536;
+
+        if (vertex_data_size > max_buffer_size) {
+            std.log.err("Vertex data size {} exceeds buffer size {}", .{ vertex_data_size, max_buffer_size });
+            return;
+        }
+
+        if (vertex_data_size > 0) {
+            ctx.queue.?.writeBuffer(
+                ctx.vertex_buffer.?,
+                0,
+                ctx.vertex_data.items.ptr,
+                vertex_data_size,
+            );
+
+            if (ctx.render_pipeline) |pipeline| {
+                render_pass.setPipeline(pipeline);
+
+                for (ctx.draw_calls.items) |draw_call| {
+                    render_pass.setBindGroup(0, draw_call.bind_group, 0, null);
+                    render_pass.setVertexBuffer(0, ctx.vertex_buffer.?, draw_call.vertex_offset * @sizeOf(Vertex), draw_call.vertex_count * @sizeOf(Vertex));
+                    render_pass.draw(draw_call.vertex_count, 1, 0, 0);
+                }
+            }
+        }
+    }
+
+    ig.ImGui_ImplWGPU_RenderDrawData(draw_data, render_pass);
+
+    render_pass.end();
+
+    const command_buffer_desc = wgpu.CommandBufferDescriptor{
+        .label = wgpu.StringView.fromSlice("Command Buffer"),
+    };
+    const command_buffer = encoder.finish(&command_buffer_desc) orelse {
+        std.log.err("Failed to finish command buffer", .{});
+        return;
+    };
+    defer command_buffer.release();
+
+    ctx.queue.?.submit(&[_]*wgpu.CommandBuffer{command_buffer});
+    _ = ctx.surface.?.present();
+}
+
+pub fn resize(ctx: *Context, width: i32, height: i32) RendererInterface.Error!void {
+    ctx.width = @intCast(width);
+    ctx.height = @intCast(height);
+
+    ig.ImGui_ImplWGPU_InvalidateDeviceObjects();
+
+    ctx.surface_config.width = ctx.width;
+    ctx.surface_config.height = ctx.height;
+    ctx.surface.?.configure(&ctx.surface_config);
+
+    if (!ig.ImGui_ImplWGPU_CreateDeviceObjects()) {
+        std.log.err("Failed to recreate ImGui device objects after resize", .{});
+        return RendererInterface.Error.InitializationFailed;
+    }
+
+    std.log.info("WGPU Renderer resized to {}x{}", .{ width, height });
+}
+
+pub fn setVSync(ctx: *Context, enabled: bool) RendererInterface.Error!void {
+    ctx.surface_config.present_mode = if (enabled) .fifo else .immediate;
+    ctx.surface.?.configure(&ctx.surface_config);
+    std.log.info("WGPU Renderer VSync set to: {}", .{enabled});
+}
+
+pub fn loadTexture(ctx: *Context, path: []const u8) RendererInterface.Error!Texture {
+    const surface = sdl.c.IMG_Load(path.ptr);
+    if (surface == null) {
+        std.log.err("Failed to load image: {s}", .{path});
+        return RendererInterface.Error.InitializationFailed;
+    }
+    defer sdl.c.SDL_DestroySurface(surface);
+
+    const width: u32 = @intCast(surface.*.w);
+    const height: u32 = @intCast(surface.*.h);
+    const size = width * height * 4; // RGBA
+
+    const rgba_surface = sdl.c.SDL_ConvertSurface(surface, sdl.c.SDL_PIXELFORMAT_RGBA32);
+    if (rgba_surface == null) {
+        std.log.err("Failed to convert surface to RGBA", .{});
+        return RendererInterface.Error.InitializationFailed;
+    }
+    defer sdl.c.SDL_DestroySurface(rgba_surface);
+
+    const texture_desc = wgpu.TextureDescriptor{
+        .label = wgpu.StringView.fromSlice("Loaded Texture"),
+        .usage = wgpu.TextureUsages.texture_binding | wgpu.TextureUsages.copy_dst,
+        .dimension = .@"2d",
+        .size = wgpu.Extent3D{
+            .width = width,
+            .height = height,
+            .depth_or_array_layers = 1,
+        },
+        .format = .rgba8_unorm,
+        .mip_level_count = 1,
+        .sample_count = 1,
+        .view_format_count = 0,
+        .view_formats = &[_]wgpu.TextureFormat{},
+    };
+
+    const texture = ctx.device.?.createTexture(&texture_desc) orelse {
+        std.log.err("Failed to create texture", .{});
+        return RendererInterface.Error.InitializationFailed;
+    };
+
+    const texel_copy_texture = wgpu.TexelCopyTextureInfo{
+        .texture = texture,
+        .mip_level = 0,
+        .origin = wgpu.Origin3D{ .x = 0, .y = 0, .z = 0 },
+        .aspect = .all,
+    };
+
+    const texel_copy_layout = wgpu.TexelCopyBufferLayout{
+        .offset = 0,
+        .bytes_per_row = width * 4,
+        .rows_per_image = height,
+    };
+
+    ctx.queue.?.writeTexture(
+        &texel_copy_texture,
+        @ptrCast(rgba_surface.*.pixels.?),
+        size,
+        &texel_copy_layout,
+        &wgpu.Extent3D{
+            .width = width,
+            .height = height,
+            .depth_or_array_layers = 1,
+        },
+    );
+
+    const view = texture.createView(null);
+
+    const bind_group = ctx.device.?.createBindGroup(&wgpu.BindGroupDescriptor{
+        .label = wgpu.StringView.fromSlice("Texture Bind Group"),
+        .layout = ctx.bind_group_layout.?,
+        .entry_count = 2,
+        .entries = &[_]wgpu.BindGroupEntry{
+            .{
+                .binding = 0,
+                .texture_view = view,
+            },
+            .{
+                .binding = 1,
+                .sampler = ctx.sampler.?,
+            },
+        },
+    });
+
+    if (bind_group == null) {
+        std.log.err("Failed to create bind group for texture", .{});
+        return RendererInterface.Error.InitializationFailed;
+    }
+
+    std.log.info("Texture loaded successfully: {}x{}", .{ width, height });
+
+    return Texture{
+        .texture = texture,
+        .view = view.?,
+        .bind_group = bind_group.?,
+        .width = width,
+        .height = height,
+    };
+}
+
+pub fn destroyTexture(tex: Texture) void {
+    tex.bind_group.release();
+    tex.view.release();
+    tex.texture.release();
+}
+
+pub fn drawTexture(
+    ctx: *Context,
+    texture: Texture,
+    src: ?RendererInterface.Rect,
+    dst: RendererInterface.Rect,
+) RendererInterface.Error!void {
+    if (ctx.render_pipeline == null) {
+        std.log.err("Render pipeline not initialized", .{});
+        return;
+    }
+
+    const vertex_offset = @as(u32, @intCast(ctx.vertex_data.items.len));
+
+    const x0 = dst.x / @as(f32, @floatFromInt(ctx.width)) * 2.0 - 1.0;
+    const y0 = 1.0 - dst.y / @as(f32, @floatFromInt(ctx.height)) * 2.0;
+    const x1 = (dst.x + dst.w) / @as(f32, @floatFromInt(ctx.width)) * 2.0 - 1.0;
+    const y1 = 1.0 - (dst.y + dst.h) / @as(f32, @floatFromInt(ctx.height)) * 2.0;
+
+    const tex_u0: f32 = if (src) |s| s.x / @as(f32, @floatFromInt(texture.width)) else 0.0;
+    const tex_v0: f32 = if (src) |s| s.y / @as(f32, @floatFromInt(texture.height)) else 0.0;
+    const tex_u1: f32 = if (src) |s| (s.x + s.w) / @as(f32, @floatFromInt(texture.width)) else 1.0;
+    const tex_v1: f32 = if (src) |s| (s.y + s.h) / @as(f32, @floatFromInt(texture.height)) else 1.0;
+
+    try ctx.vertex_data.append(.{ .position = .{ x0, y0 }, .tex_coords = .{ tex_u0, tex_v0 } });
+    try ctx.vertex_data.append(.{ .position = .{ x1, y0 }, .tex_coords = .{ tex_u1, tex_v0 } });
+    try ctx.vertex_data.append(.{ .position = .{ x1, y1 }, .tex_coords = .{ tex_u1, tex_v1 } });
+    try ctx.vertex_data.append(.{ .position = .{ x0, y0 }, .tex_coords = .{ tex_u0, tex_v0 } });
+    try ctx.vertex_data.append(.{ .position = .{ x1, y1 }, .tex_coords = .{ tex_u1, tex_v1 } });
+    try ctx.vertex_data.append(.{ .position = .{ x0, y1 }, .tex_coords = .{ tex_u0, tex_v1 } });
+
+    try ctx.draw_calls.append(.{
+        .texture_view = texture.view,
+        .bind_group = texture.bind_group,
+        .vertex_offset = vertex_offset,
+        .vertex_count = 6,
+    });
+}
+
+pub fn drawTextureBatch(
+    ctx: *Context,
+    texture: Texture,
+    src: ?RendererInterface.Rect,
+    dst: []RendererInterface.Rect,
+) RendererInterface.Error!void {
+    if (dst.len == 0) return;
+    if (ctx.render_pipeline == null) {
+        std.log.err("Render pipeline not initialized", .{});
+        return;
+    }
+
+    const vertex_offset = @as(u32, @intCast(ctx.vertex_data.items.len));
+
+    try ctx.vertex_data.ensureUnusedCapacity(dst.len * 6);
+
+    for (dst) |rect| {
+        const x0 = rect.x / @as(f32, @floatFromInt(ctx.width)) * 2.0 - 1.0;
+        const y0 = 1.0 - rect.y / @as(f32, @floatFromInt(ctx.height)) * 2.0;
+        const x1 = (rect.x + rect.w) / @as(f32, @floatFromInt(ctx.width)) * 2.0 - 1.0;
+        const y1 = 1.0 - (rect.y + rect.h) / @as(f32, @floatFromInt(ctx.height)) * 2.0;
+
+        const tex_u0: f32 = if (src) |s| s.x / @as(f32, @floatFromInt(texture.width)) else 0.0;
+        const tex_v0: f32 = if (src) |s| s.y / @as(f32, @floatFromInt(texture.height)) else 0.0;
+        const tex_u1: f32 = if (src) |s| (s.x + s.w) / @as(f32, @floatFromInt(texture.width)) else 1.0;
+        const tex_v1: f32 = if (src) |s| (s.y + s.h) / @as(f32, @floatFromInt(texture.height)) else 1.0;
+
+        try ctx.vertex_data.append(.{ .position = .{ x0, y0 }, .tex_coords = .{ tex_u0, tex_v0 } });
+        try ctx.vertex_data.append(.{ .position = .{ x1, y0 }, .tex_coords = .{ tex_u1, tex_v0 } });
+        try ctx.vertex_data.append(.{ .position = .{ x1, y1 }, .tex_coords = .{ tex_u1, tex_v1 } });
+        try ctx.vertex_data.append(.{ .position = .{ x0, y0 }, .tex_coords = .{ tex_u0, tex_v0 } });
+        try ctx.vertex_data.append(.{ .position = .{ x1, y1 }, .tex_coords = .{ tex_u1, tex_v1 } });
+        try ctx.vertex_data.append(.{ .position = .{ x0, y1 }, .tex_coords = .{ tex_u0, tex_v1 } });
+    }
+
+    const vertex_count = @as(u32, @intCast(ctx.vertex_data.items.len - vertex_offset));
+
+    try ctx.draw_calls.append(.{
+        .texture_view = texture.view,
+        .bind_group = texture.bind_group,
+        .vertex_offset = vertex_offset,
+        .vertex_count = vertex_count,
+    });
+}
+
+fn createSurfaceFromSDLWindow(instance: *wgpu.Instance, window: *sdl.c.SDL_Window) !*wgpu.Surface {
+    const props = sdl.c.SDL_GetWindowProperties(window);
+    if (props == 0) {
+        std.log.err("Failed to get window properties", .{});
+        return RendererInterface.Error.UnsupportedBackend;
+    }
+
+    // macOS/Cocoa
+    if (sdl.c.SDL_GetPointerProperty(props, "SDL.window.cocoa.window", null)) |cocoa_window| {
+        const metal_view = sdl.c.SDL_Metal_CreateView(window);
+        if (metal_view) |view| {
+            const layer = sdl.c.SDL_Metal_GetLayer(view);
+            if (layer) |metal_layer| {
+                const desc = wgpu.surfaceDescriptorFromMetalLayer(.{
+                    .layer = metal_layer,
+                });
+                return instance.createSurface(&desc) orelse {
+                    std.log.err("Failed to create WGPU surface from Metal layer", .{});
+                    return RendererInterface.Error.InitializationFailed;
+                };
+            }
+        }
+        _ = cocoa_window; // suppress unused warning
+    }
+
+    // Windows
+    if (sdl.c.SDL_GetPointerProperty(props, "SDL.window.win32.hwnd", null)) |hwnd| {
+        if (sdl.c.SDL_GetPointerProperty(props, "SDL.window.win32.hinstance", null)) |hinstance| {
+            const desc = wgpu.surfaceDescriptorFromWindowsHWND(.{
+                .hinstance = hinstance,
+                .hwnd = hwnd,
+            });
+            return instance.createSurface(&desc) orelse {
+                std.log.err("Failed to create WGPU surface from HWND", .{});
+                return RendererInterface.Error.InitializationFailed;
+            };
+        }
+    }
+
+    // Check for X11
+    const x11_window = sdl.c.SDL_GetNumberProperty(props, "SDL.window.x11.window", 0);
+    if (x11_window != 0) {
+        if (sdl.c.SDL_GetPointerProperty(props, "SDL.window.x11.display", null)) |x11_display| {
+            const desc = wgpu.surfaceDescriptorFromXlibWindow(.{
+                .display = x11_display,
+                .window = @intCast(x11_window),
+            });
+            return instance.createSurface(&desc) orelse {
+                std.log.err("Failed to create WGPU surface from X11 window", .{});
+                return RendererInterface.Error.InitializationFailed;
+            };
+        }
+    }
+
+    // Wayland
+    if (sdl.c.SDL_GetPointerProperty(props, "SDL.window.wayland.surface", null)) |wl_surface| {
+        if (sdl.c.SDL_GetPointerProperty(props, "SDL.window.wayland.display", null)) |wl_display| {
+            const desc = wgpu.surfaceDescriptorFromWaylandSurface(.{
+                .display = wl_display,
+                .surface = wl_surface,
+            });
+            return instance.createSurface(&desc) orelse {
+                std.log.err("Failed to create WGPU surface from Wayland surface", .{});
+                return RendererInterface.Error.InitializationFailed;
+            };
+        }
+    }
+
+    std.log.err("Unsupported platform for WGPU surface creation", .{});
+    return RendererInterface.Error.UnsupportedBackend;
+}
+
+fn createTextureResources(ctx: *Context) !void {
+    const sampler_desc = wgpu.SamplerDescriptor{
+        .label = wgpu.StringView.fromSlice("Texture Sampler"),
+        .address_mode_u = .clamp_to_edge,
+        .address_mode_v = .clamp_to_edge,
+        .address_mode_w = .clamp_to_edge,
+        .mag_filter = .linear,
+        .min_filter = .linear,
+        .mipmap_filter = .linear,
+        .lod_min_clamp = 0.0,
+        .lod_max_clamp = 32.0,
+        .compare = .undefined,
+        .max_anisotropy = 1,
+    };
+    ctx.sampler = ctx.device.?.createSampler(&sampler_desc);
+
+    const bind_group_layout_desc = wgpu.BindGroupLayoutDescriptor{
+        .label = wgpu.StringView.fromSlice("Texture Bind Group Layout"),
+        .entry_count = 2,
+        .entries = &[_]wgpu.BindGroupLayoutEntry{
+            .{
+                .binding = 0,
+                .visibility = wgpu.ShaderStages.fragment,
+                .texture = wgpu.TextureBindingLayout{
+                    .sample_type = .float,
+                    .view_dimension = .@"2d",
+                    .multisampled = 0,
+                },
+                .sampler = wgpu.SamplerBindingLayout{
+                    .type = .binding_not_used,
+                },
+                .buffer = wgpu.BufferBindingLayout{
+                    .type = .binding_not_used,
+                },
+                .storage_texture = wgpu.StorageTextureBindingLayout{
+                    .access = .binding_not_used,
+                },
+            },
+            .{
+                .binding = 1,
+                .visibility = wgpu.ShaderStages.fragment,
+                .sampler = wgpu.SamplerBindingLayout{
+                    .type = .filtering,
+                },
+                .texture = wgpu.TextureBindingLayout{
+                    .sample_type = .binding_not_used,
+                },
+                .buffer = wgpu.BufferBindingLayout{
+                    .type = .binding_not_used,
+                },
+                .storage_texture = wgpu.StorageTextureBindingLayout{
+                    .access = .binding_not_used,
+                },
+            },
+        },
+    };
+    ctx.bind_group_layout = ctx.device.?.createBindGroupLayout(&bind_group_layout_desc);
+}
+
+fn createRenderPipeline(ctx: *Context) !void {
+    const shader_source =
+        \\struct VertexOutput {
+        \\    @builtin(position) clip_position: vec4f,
+        \\    @location(0) tex_coords: vec2f,
+        \\}
+        \\
+        \\@vertex
+        \\fn vs_main(@location(0) position: vec2f, @location(1) tex_coords: vec2f) -> VertexOutput {
+        \\    var out: VertexOutput;
+        \\    out.clip_position = vec4f(position, 0.0, 1.0);
+        \\    out.tex_coords = tex_coords;
+        \\    return out;
+        \\}
+        \\
+        \\@group(0) @binding(0) var texture_view: texture_2d<f32>;
+        \\@group(0) @binding(1) var texture_sampler: sampler;
+        \\
+        \\@fragment
+        \\fn fs_main(in: VertexOutput) -> @location(0) vec4f {
+        \\    return textureSample(texture_view, texture_sampler, in.tex_coords);
+        \\}
+    ;
+
+    const shader_desc = wgpu.shaderModuleWGSLDescriptor(.{
+        .label = "Texture Shader",
+        .code = shader_source,
+    });
+    const shader_module = ctx.device.?.createShaderModule(&shader_desc) orelse {
+        std.log.err("Failed to create shader module", .{});
+        return RendererInterface.Error.InitializationFailed;
+    };
+    defer shader_module.release();
+
+    const pipeline_layout_desc = wgpu.PipelineLayoutDescriptor{
+        .label = wgpu.StringView.fromSlice("Render Pipeline Layout"),
+        .bind_group_layout_count = 1,
+        .bind_group_layouts = &[_]*wgpu.BindGroupLayout{ctx.bind_group_layout.?},
+    };
+    const pipeline_layout = ctx.device.?.createPipelineLayout(&pipeline_layout_desc) orelse {
+        std.log.err("Failed to create pipeline layout", .{});
+        return RendererInterface.Error.InitializationFailed;
+    };
+    defer pipeline_layout.release();
+
+    const vertex_attributes = [_]wgpu.VertexAttribute{
+        .{
+            .offset = 0,
+            .shader_location = 0,
+            .format = .float32x2,
+        },
+        .{
+            .offset = @offsetOf(Vertex, "tex_coords"),
+            .shader_location = 1,
+            .format = .float32x2,
+        },
+    };
+
+    const vertex_buffer_layout = wgpu.VertexBufferLayout{
+        .array_stride = @sizeOf(Vertex),
+        .step_mode = .vertex,
+        .attribute_count = vertex_attributes.len,
+        .attributes = &vertex_attributes,
+    };
+
+    const render_pipeline_desc = wgpu.RenderPipelineDescriptor{
+        .label = wgpu.StringView.fromSlice("Render Pipeline"),
+        .layout = pipeline_layout,
+        .vertex = wgpu.VertexState{
+            .module = shader_module,
+            .entry_point = wgpu.StringView.fromSlice("vs_main"),
+            .buffer_count = 1,
+            .buffers = &[_]wgpu.VertexBufferLayout{vertex_buffer_layout},
+        },
+        .primitive = wgpu.PrimitiveState{
+            .topology = .triangle_list,
+            .strip_index_format = .undefined,
+            .front_face = .ccw,
+            .cull_mode = .none,
+        },
+        .depth_stencil = null,
+        .multisample = wgpu.MultisampleState{
+            .count = 1,
+            .mask = ~@as(u32, 0),
+            .alpha_to_coverage_enabled = 0,
+        },
+        .fragment = &wgpu.FragmentState{
+            .module = shader_module,
+            .entry_point = wgpu.StringView.fromSlice("fs_main"),
+            .target_count = 1,
+            .targets = &[_]wgpu.ColorTargetState{
+                .{
+                    .format = ctx.surface_config.format,
+                    .blend = &wgpu.BlendState{
+                        .color = wgpu.BlendComponent{
+                            .src_factor = .src_alpha,
+                            .dst_factor = .one_minus_src_alpha,
+                            .operation = .add,
+                        },
+                        .alpha = wgpu.BlendComponent{
+                            .src_factor = .one,
+                            .dst_factor = .zero,
+                            .operation = .add,
+                        },
+                    },
+                    .write_mask = wgpu.ColorWriteMasks.all,
+                },
+            },
+        },
+    };
+
+    ctx.render_pipeline = ctx.device.?.createRenderPipeline(&render_pipeline_desc);
+    if (ctx.render_pipeline == null) {
+        std.log.err("Failed to create render pipeline!", .{});
+        return RendererInterface.Error.InitializationFailed;
+    }
+    std.log.info("Render pipeline created successfully", .{});
+}

--- a/src/rendering/renderer.zig
+++ b/src/rendering/renderer.zig
@@ -7,6 +7,7 @@ pub const BackendType = enum {
     SDL,
     OpenGL,
     Metal,
+    WGPU,
 
     pub fn default(
         _: std.Target,
@@ -33,6 +34,7 @@ pub const Backend = switch (build_config.renderer) {
     .SDL => @import("backend/sdl.zig"),
     .OpenGL => @import("backend/opengl.zig"),
     .Metal => unreachable,
+    .WGPU => @import("backend/wgpu.zig"),
 };
 pub const Context = Backend.Context;
 
@@ -65,8 +67,8 @@ pub fn newImGuiFrame() void {
     Backend.newImGuiFrame();
 }
 
-pub fn renderImGui(ctx: *Context, draw_data: *ig.c.ImDrawData) void {
-    Backend.renderImGui(ctx, draw_data);
+pub fn renderImGui(ctx: *Context, draw_data: *ig.c.ImDrawData, clear_color: ig.c.ImVec4) void {
+    Backend.renderImGui(ctx, draw_data, clear_color);
 }
 
 pub fn resize(ctx: *Context, width: i32, height: i32) Error!void {

--- a/src/rendering/renderer.zig
+++ b/src/rendering/renderer.zig
@@ -6,15 +6,12 @@ const build_config = @import("../build_config.zig");
 pub const BackendType = enum {
     SDL,
     OpenGL,
-    Metal,
     WGPU,
 
     pub fn default(
         _: std.Target,
     ) BackendType {
-        // TODO: Uncomment this once we add metal as a backend
-        // if (target.os.tag.isDarwin()) return .Metal;
-        return .SDL;
+        return .WGPU;
     }
 };
 
@@ -33,7 +30,6 @@ pub const Error = error{
 pub const Backend = switch (build_config.renderer) {
     .SDL => @import("backend/sdl.zig"),
     .OpenGL => @import("backend/opengl.zig"),
-    .Metal => unreachable,
     .WGPU => @import("backend/wgpu.zig"),
 };
 pub const Context = Backend.Context;
@@ -75,7 +71,7 @@ pub fn resize(ctx: *Context, width: i32, height: i32) Error!void {
     try Backend.resize(ctx, width, height);
 }
 
-pub fn setVSync(ctx: *Context, enabled: bool) Error!void { // Add this method
+pub fn setVSync(ctx: *Context, enabled: bool) Error!void {
     try Backend.setVSync(ctx, enabled);
 }
 

--- a/vendor/cimgui/build.zig
+++ b/vendor/cimgui/build.zig
@@ -3,11 +3,11 @@ const wgpu = @import("wgpu/root.zig");
 
 pub fn build(b: *std.Build) !void {
     const renderer_opt = b.option(
-        enum { SDL, OpenGL, Metal, WGPU },
+        enum { SDL, OpenGL, WGPU },
         "renderer",
-        "Renderer backend: sdl | opengl | metal (default: sdl)",
+        "Renderer backend: sdl | opengl | wgpu (default: wgpu)",
     );
-    const renderer = renderer_opt orelse .SDL;
+    const renderer = renderer_opt orelse .WGPU;
 
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
@@ -20,10 +20,6 @@ pub fn build(b: *std.Build) !void {
         .target = target,
         .optimize = optimize,
     });
-    // const wgpu_native_dep = b.dependency("wgpu_native_zig", .{
-    //     .target = target,
-    //     .optimize = optimize,
-    // });
 
     const sdl_image_dep = b.dependency("SDL_image", .{
         .target = target,

--- a/vendor/cimgui/build.zig.zon
+++ b/vendor/cimgui/build.zig.zon
@@ -16,6 +16,90 @@
             .url = "git+https://github.com/allyourcodebase/SDL_image#45a1701cff2bee5c6b00d5937e9a158c26a834c9",
             .hash = "SDL_image-3.2.0--aJoHa0VAADeiIBoPYI3tyYE1OPF9t_C1cuCU1n7P5TG",
         },
+
+        // WGPU Includes
+        // src: https://github.com/bronter/wgpu_native_zig/tree/v5.1.0
+        // tag: v5.1.0
+        .wgpu_linux_aarch64_debug = .{
+            .url = "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-linux-aarch64-debug.zip",
+            .hash = "N-V-__8AALSbGhS93ZKwkkKk-yN3BzFl6iBPh9etfftVkhSk",
+            .lazy = true,
+        },
+        .wgpu_linux_aarch64_release = .{
+            .url = "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-linux-aarch64-release.zip",
+            .hash = "N-V-__8AAC42tgMsCqChk-HZ0n7dyD1HT29f6QM0UTCdj_iF",
+            .lazy = true,
+        },
+        .wgpu_linux_x86_64_debug = .{
+            .url = "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-linux-x86_64-debug.zip",
+            .hash = "N-V-__8AAHS_-BNtAmT4hK9geZG361RETmD2lG0fk2gyDYh-",
+            .lazy = true,
+        },
+        .wgpu_linux_x86_64_release = .{
+            .url = "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-linux-x86_64-release.zip",
+            .hash = "N-V-__8AALK1sQPqMGESXUOHBpzwDj1GMf_nYBdfbjewJ9kH",
+            .lazy = true,
+        },
+        .wgpu_macos_aarch64_debug = .{
+            .url = "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-macos-aarch64-debug.zip",
+            .hash = "N-V-__8AACj6lQmZEGeyjdn2CCD0as1hGMvrAUBsoTuBu_cR",
+            .lazy = true,
+        },
+        .wgpu_macos_aarch64_release = .{
+            .url = "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-macos-aarch64-release.zip",
+            .hash = "N-V-__8AAGDGYgIAQ6tOKxxonhabDmuFj9Y35AKvPwynW_UO",
+            .lazy = true,
+        },
+        .wgpu_macos_x86_64_debug = .{
+            .url = "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-macos-x86_64-debug.zip",
+            .hash = "N-V-__8AAOCufAlp1bMuFqQCd152bYQLNu-tjLdu9edJ8b4e",
+            .lazy = true,
+        },
+        .wgpu_macos_x86_64_release = .{
+            .url = "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-macos-x86_64-release.zip",
+            .hash = "N-V-__8AAFi6YgLHU9dEEx9n190MvnIZaCq5SVMg8BX7zD87",
+            .lazy = true,
+        },
+        .wgpu_windows_aarch64_msvc_debug = .{
+            .url = "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-windows-aarch64-msvc-debug.zip",
+            .hash = "N-V-__8AACUsDR0QuXpFRCjd-TcdKredsnN5Uiy6thaqghfy",
+            .lazy = true,
+        },
+        .wgpu_windows_aarch64_msvc_release = .{
+            .url = "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-windows-aarch64-msvc-release.zip",
+            .hash = "N-V-__8AAEmpwwOechqvtlmAlMzCIbnIzIgSYcfEUWhSZ7Cj",
+            .lazy = true,
+        },
+        .wgpu_windows_x86_msvc_debug = .{
+            .url = "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-windows-i686-msvc-debug.zip",
+            .hash = "N-V-__8AAP8AIx3OgW8N8DkBj5JMcJUkcy7iHLuOH--fY3IX",
+            .lazy = true,
+        },
+        .wgpu_windows_x86_msvc_release = .{
+            .url = "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-windows-i686-msvc-release.zip",
+            .hash = "N-V-__8AAMn2lQPoxD9cdgm97Fvxqes4Jlvwct-GWDgsws5k",
+            .lazy = true,
+        },
+        .wgpu_windows_x86_64_msvc_debug = .{
+            .url = "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-windows-x86_64-msvc-debug.zip",
+            .hash = "N-V-__8AADEvMB0uTuAXXabR4Fw-2LjtJfoSP8vux2m_eDok",
+            .lazy = true,
+        },
+        .wgpu_windows_x86_64_msvc_release = .{
+            .url = "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-windows-x86_64-msvc-release.zip",
+            .hash = "N-V-__8AAG8mAQR0Vg9K8e0Ln46g_UJq1HqtXwif_Uvt1_ZE",
+            .lazy = true,
+        },
+        .wgpu_windows_x86_64_gnu_debug = .{
+            .url = "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-windows-x86_64-gnu-debug.zip",
+            .hash = "N-V-__8AAFICSxIMF7kdKvI3pTwiLWmIxjSopWIadDt9yUpp",
+            .lazy = true,
+        },
+        .wgpu_windows_x86_64_gnu_release = .{
+            .url = "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-windows-x86_64-gnu-release.zip",
+            .hash = "N-V-__8AAMZ8DwPtTjIxd_0zIGEoJwriDQY-Ykx8ldVc_7N0",
+            .lazy = true,
+        },
     },
     .paths = .{
         "build.zig",

--- a/vendor/cimgui/main.zig
+++ b/vendor/cimgui/main.zig
@@ -57,3 +57,26 @@ pub extern fn ImGui_ImplOpenGL3_Init(glsl_version: [*:0]const u8) bool;
 pub extern fn ImGui_ImplOpenGL3_Shutdown() void;
 pub extern fn ImGui_ImplOpenGL3_NewFrame() void;
 pub extern fn ImGui_ImplOpenGL3_RenderDrawData(draw_data: ?*c.ImDrawData) void;
+
+// WGPU
+pub extern fn ImGui_ImplSDL3_InitForOther(window: ?*sdl.c.SDL_Window) callconv(.C) bool;
+
+pub const WGPUMultisampleState = extern struct {
+    next_in_chain: ?*const anyopaque,
+    count: u32,
+    mask: u32,
+    alpha_to_coverage_enabled: bool,
+};
+pub const ImGui_ImplWGPU_InitInfo = extern struct {
+    Device: ?*anyopaque,
+    NumFramesInFlight: c_int,
+    RenderTargetFormat: c_int,
+    DepthStencilFormat: c_int,
+    PipelineMultisampleState: WGPUMultisampleState,
+};
+pub extern fn ImGui_ImplWGPU_Init(init_info: *ImGui_ImplWGPU_InitInfo) callconv(.C) bool;
+pub extern fn ImGui_ImplWGPU_Shutdown() callconv(.C) void;
+pub extern fn ImGui_ImplWGPU_NewFrame() callconv(.C) void;
+pub extern fn ImGui_ImplWGPU_RenderDrawData(draw_data: ?*c.ImDrawData, pass_encoder: ?*anyopaque) callconv(.C) void;
+pub extern fn ImGui_ImplWGPU_InvalidateDeviceObjects() callconv(.C) void;
+pub extern fn ImGui_ImplWGPU_CreateDeviceObjects() callconv(.C) bool;

--- a/vendor/cimgui/wgpu/root.zig
+++ b/vendor/cimgui/wgpu/root.zig
@@ -1,0 +1,39 @@
+const std = @import("std");
+pub fn getIncludePath(
+    b: *std.Build,
+    optimize: std.builtin.OptimizeMode,
+    target: std.Build.ResolvedTarget,
+) !std.Build.LazyPath {
+    const target_res = target.result;
+    const os_str = @tagName(target_res.os.tag);
+    const arch_str = @tagName(target_res.cpu.arch);
+
+    const mode_str = switch (optimize) {
+        .Debug => "debug",
+        else => "release",
+    };
+    const abi_str = switch (target_res.os.tag) {
+        .windows => switch (target_res.abi) {
+            .msvc => "_msvc",
+            else => "_gnu",
+        },
+        else => "",
+    };
+    const target_name_slices = [_][:0]const u8{ "wgpu_", os_str, "_", arch_str, abi_str, "_", mode_str };
+    const maybe_target_name = std.mem.concatWithSentinel(b.allocator, u8, &target_name_slices, 0);
+    const target_name = maybe_target_name catch |err| {
+        std.debug.panic("Failed to format target name: {s}", .{@errorName(err)});
+    };
+    for (b.available_deps) |dep| {
+        const name, _ = dep;
+        if (std.mem.eql(u8, name, target_name)) {
+            break;
+        }
+    } else {
+        std.debug.panic("Could not find dependency matching target {s}", .{target_name});
+    }
+
+    const wgpu_dep = b.lazyDependency(target_name, .{}) orelse return error.DependencyError;
+
+    return wgpu_dep.path("include");
+}


### PR DESCRIPTION
This PR adds WGPU as a backend. This uses [WGPU-native](https://github.com/gfx-rs/wgpu-native) for use with Zig.

This will be set as the default backend for all platforms unless manually overridden by the user with `-Drenderer={SDL|OpenGL}`.

